### PR TITLE
tox.ini: Add {posargs}

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,4 +8,4 @@ envlist = py27, py33, py34, pypy
 
 [testenv]
 deps = -r{toxinidir}/requirements-test.txt
-commands = py.test tests/
+commands = py.test {posargs:tests/}


### PR DESCRIPTION
so that you can run specific tests, pass py.test options (e.g.: --pdb), etc.