### PR TITLE
Allow the `class` attr for all tags

### DIFF
--- a/readme/clean.py
+++ b/readme/clean.py
@@ -34,9 +34,8 @@ ALLOWED_ATTRIBUTES = {
     "acronym": ["title"],
 
     # Custom Additions
-    "*": ["id"],
+    "*": ["id", "class"],
     "img": ["src"],
-    "span": ["class"],
 }
 
 ALLOWED_STYLES = []

--- a/tests/fixtures/test_rst_002.html
+++ b/tests/fixtures/test_rst_002.html
@@ -1,0 +1,1 @@
+<p><a class="reference external" href="http://mymalicioussite.com/" rel="nofollow">http://mymalicioussite.com/</a></p>

--- a/tests/fixtures/test_rst_002.rst
+++ b/tests/fixtures/test_rst_002.rst
@@ -1,0 +1,1 @@
+http://mymalicioussite.com/

--- a/tests/fixtures/test_rst_003.html
+++ b/tests/fixtures/test_rst_003.html
@@ -1,8 +1,8 @@
-<div id="required-packages">
+<div class="section" id="required-packages">
 <h2>Required packages</h2>
 <p>To run the PyPI software, you need Python 2.5+ and PostgreSQL</p>
 </div>
-<div id="quick-development-setup">
+<div class="section" id="quick-development-setup">
 <h2>Quick development setup</h2>
 <p>Make sure you are sitting</p>
 </div>

--- a/tests/fixtures/test_rst_005.html
+++ b/tests/fixtures/test_rst_005.html
@@ -1,1 +1,1 @@
-<p>&lt;a href=”<a href="http://mymalicioussite.com/" rel="nofollow">http://mymalicioussite.com/</a>”&gt;Click here&lt;/a&gt;</p>
+<p>&lt;a href=”<a class="reference external" href="http://mymalicioussite.com/" rel="nofollow">http://mymalicioussite.com/</a>”&gt;Click here&lt;/a&gt;</p>

--- a/tests/fixtures/test_rst_006.html
+++ b/tests/fixtures/test_rst_006.html
@@ -1,1 +1,1 @@
-<p>&lt;iframe src=”<a href="http://mymalicioussite.com/" rel="nofollow">http://mymalicioussite.com/</a>”&gt;Click here&lt;/iframe&gt;</p>
+<p>&lt;iframe src=”<a class="reference external" href="http://mymalicioussite.com/" rel="nofollow">http://mymalicioussite.com/</a>”&gt;Click here&lt;/iframe&gt;</p>

--- a/tests/fixtures/test_rst_008.html
+++ b/tests/fixtures/test_rst_008.html
@@ -1,5 +1,5 @@
-<p>Here is some Python code for a <tt>Dog</tt>:</p>
-<pre><span class="k">class</span> <span class="nc">Dog</span><span class="p">(</span><span class="n">Animal</span><span class="p">):</span>
+<p>Here is some Python code for a <tt class="docutils literal">Dog</tt>:</p>
+<pre class="code python literal-block"><span class="k">class</span> <span class="nc">Dog</span><span class="p">(</span><span class="n">Animal</span><span class="p">):</span>
     <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">name</span><span class="p">):</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">=</span> <span class="n">name</span>
 
@@ -9,8 +9,8 @@
 <span class="n">dog</span> <span class="o">=</span> <span class="n">Dog</span><span class="p">(</span><span class="s">'Fido'</span><span class="p">)</span>
 </pre>
 <p>and then here is some bash:</p>
-<pre><span class="k">if</span> <span class="o">[</span> <span class="s2">"</span><span class="nv">$1</span><span class="s2">"</span> <span class="o">=</span> <span class="s2">"--help"</span> <span class="o">]</span><span class="p">;</span> <span class="k">then</span>
+<pre class="code bash literal-block"><span class="k">if</span> <span class="o">[</span> <span class="s2">"</span><span class="nv">$1</span><span class="s2">"</span> <span class="o">=</span> <span class="s2">"--help"</span> <span class="o">]</span><span class="p">;</span> <span class="k">then</span>
     <span class="nb">echo</span> <span class="s2">"OK"</span>
 <span class="k">fi</span>
 </pre>
-<p>or click <a href="http://www.surveymonkey.com" rel="nofollow">SurveyMonkey</a></p>
+<p>or click <a class="reference external" href="http://www.surveymonkey.com" rel="nofollow">SurveyMonkey</a></p>

--- a/tests/test_rst.py
+++ b/tests/test_rst.py
@@ -9,10 +9,7 @@ def test_rst_001():
 
 
 def test_rst_002():
-    assert render('http://mymalicioussite.com/') == (
-        ('<p><a href="http://mymalicioussite.com/" rel="nofollow">' +
-         'http://mymalicioussite.com/</a></p>\n'),
-        True)
+    _do_test_with_files('test_rst_002')
 
 
 def test_rst_003():


### PR DESCRIPTION
because we want to use this module in PyPI and PyPI's current generated HTML has these `class` attributes.