### PR TITLE
Disable initial_header_level=2

### DIFF
--- a/readme/rst.py
+++ b/readme/rst.py
@@ -33,7 +33,7 @@ SETTINGS = {
     "doctitle_xform": True,
 
     # Set our initial header level
-    "initial_header_level": 2,
+    # "initial_header_level": 2,
 
     # Prevent local files from being included into the rendered output.
     # This is a security concern because people can insert files

--- a/tests/fixtures/test_rst_003.html
+++ b/tests/fixtures/test_rst_003.html
@@ -1,8 +1,8 @@
 <div id="required-packages">
-<h2>Required packages</h2>
+<h1>Required packages</h1>
 <p>To run the PyPI software, you need Python 2.5+ and PostgreSQL</p>
 </div>
 <div id="quick-development-setup">
-<h2>Quick development setup</h2>
+<h1>Quick development setup</h1>
 <p>Make sure you are sitting</p>
 </div>


### PR DESCRIPTION
PyPI needs this to be 1 (the default). So we either need to remove this or make it configurable.