### PR TITLE
Make clean and linkify configurable

### DIFF
--- a/readme/clean.py
+++ b/readme/clean.py
@@ -43,30 +43,10 @@ ALLOWED_STYLES = []
 
 
 def clean(html):
-    def nofollow(attrs, new=False):
-        if attrs["href"].startswith("mailto:"):
-            return attrs
-        attrs["rel"] = "nofollow"
-        return attrs
-
     # Clean the output using Bleach
-    cleaned = bleach.clean(
+    return bleach.clean(
         html,
         tags=ALLOWED_TAGS,
         attributes=ALLOWED_ATTRIBUTES,
         styles=ALLOWED_STYLES,
     )
-
-    # Bleach Linkify makes it easy to modify links, however, we will not be
-    # using it to create additional links.
-    cleaned = bleach.linkify(
-        cleaned,
-        callbacks=[
-            lambda attrs, new: attrs if not new else None,
-            nofollow,
-        ],
-        skip_pre=True,
-        parse_email=False,
-    )
-
-    return cleaned

--- a/readme/linkify.py
+++ b/readme/linkify.py
@@ -1,0 +1,36 @@
+# Copyright 2014 Donald Stufft
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import, division, print_function
+
+import bleach
+
+
+def linkify(html):
+    def nofollow(attrs, new=False):
+        if attrs["href"].startswith("mailto:"):
+            return attrs
+        attrs["rel"] = "nofollow"
+        return attrs
+
+    # Bleach Linkify makes it easy to modify links, however, we will not be
+    # using it to create additional links.
+    return bleach.linkify(
+        html,
+        callbacks=[
+            lambda attrs, new: attrs if not new else None,
+            nofollow,
+        ],
+        skip_pre=True,
+        parse_email=False,
+    )

--- a/readme/rst.py
+++ b/readme/rst.py
@@ -20,6 +20,7 @@ from docutils.writers.html4css1 import HTMLTranslator, Writer
 from docutils.utils import SystemMessage
 
 from .clean import clean
+from .linkify import linkify
 
 
 SETTINGS = {
@@ -68,7 +69,7 @@ SETTINGS = {
 }
 
 
-def render(raw):
+def render(raw, clean=clean, linkify=linkify):
     # Use a io.StringIO as the warning stream to prevent warnings from being
     # printed to sys.stderr.
     settings = SETTINGS.copy()
@@ -84,4 +85,11 @@ def render(raw):
     else:
         rendered = parts.get("fragment")
 
-    return clean(rendered or raw), bool(rendered)
+    doc = rendered or raw
+
+    if clean:
+        doc = clean(doc)
+    if linkify:
+        doc = linkify(doc)
+
+    return doc, bool(rendered)


### PR DESCRIPTION
`clean` and `linkify` are optional parameters to the `render` function. The caller can provider their own callable for these or they can set them to `None` to turn them off completely.

PyPI, in particular, needed the ability to turn `linkify` off, because it's adding extra `rel="nofollow"` attributes to links that it doesn't have (but maybe should when it switches to using pypa/readme?)