### PR TITLE
Disable smart quotes

### DIFF
--- a/readme/rst.py
+++ b/readme/rst.py
@@ -57,7 +57,7 @@ SETTINGS = {
 
     # Use typographic quotes, and transform --, ---, and ... into their
     # typographic counterparts.
-    "smart_quotes": True,
+    # "smart_quotes": True,
 
     # Strip all comments from the rendered output.
     "strip_comments": True,

--- a/tests/fixtures/test_rst_004.html
+++ b/tests/fixtures/test_rst_004.html
@@ -1,8 +1,8 @@
-<p>&lt;div id=”required-packages”&gt;
+<p>&lt;div id="required-packages"&gt;
 &lt;h2&gt;Required packages&lt;/h2&gt;
 &lt;p&gt;To run the PyPI software, you need Python 2.5+ and PostgreSQL&lt;/p&gt;
 &lt;/div&gt;
-&lt;div id=”quick-development-setup”&gt;
+&lt;div id="quick-development-setup"&gt;
 &lt;h2&gt;Quick development setup&lt;/h2&gt;
 &lt;p&gt;Make sure you are sitting&lt;/p&gt;
 &lt;/div&gt;</p>

--- a/tests/fixtures/test_rst_005.html
+++ b/tests/fixtures/test_rst_005.html
@@ -1,1 +1,1 @@
-<p>&lt;a href=”<a href="http://mymalicioussite.com/" rel="nofollow">http://mymalicioussite.com/</a>”&gt;Click here&lt;/a&gt;</p>
+<p>&lt;a href="<a href="http://mymalicioussite.com/" rel="nofollow">http://mymalicioussite.com/</a>"&gt;Click here&lt;/a&gt;</p>

--- a/tests/fixtures/test_rst_006.html
+++ b/tests/fixtures/test_rst_006.html
@@ -1,1 +1,1 @@
-<p>&lt;iframe src=”<a href="http://mymalicioussite.com/" rel="nofollow">http://mymalicioussite.com/</a>”&gt;Click here&lt;/iframe&gt;</p>
+<p>&lt;iframe src="<a href="http://mymalicioussite.com/" rel="nofollow">http://mymalicioussite.com/</a>"&gt;Click here&lt;/iframe&gt;</p>


### PR DESCRIPTION
because PyPI doesn't use them.

We can turn it on later perhaps.