### PR TITLE
tox.ini: pep8 target: py32 => py33

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ commands =
     py.test --strict {posargs}
 
 [testenv:pep8]
-basepython = python3.2
+basepython = python3.3
 deps =
     flake8
     pep8-naming


### PR DESCRIPTION
b/c the minimum 3.x version in envlist is 3.3. Using 3.2 for the pep8 target can be problematic if some module doesn't work in 3.2.