### PR TITLE
Whitelist <kbd> and <var>

### DIFF
--- a/readme/clean.py
+++ b/readme/clean.py
@@ -24,7 +24,7 @@ ALLOWED_TAGS = [
     # Custom Additions
     "br", "cite", "col", "colgroup", "dd", "div", "dl", "dt", "h1", "h2", "h3",
     "h4", "h5", "h6", "hr", "img", "p", "pre", "span", "table", "tbody", "td",
-    "th", "thead", "tr", "tt",
+    "th", "thead", "tr", "tt", "kbd", "var",
 ]
 
 ALLOWED_ATTRIBUTES = {


### PR DESCRIPTION
docutils uses these when rendering option lists.

Should fix https://github.com/pypa/warehouse/issues/533